### PR TITLE
Add action for AccountNameChanged activity type

### DIFF
--- a/src/SFA.DAS.Activities/ActivityType.cs
+++ b/src/SFA.DAS.Activities/ActivityType.cs
@@ -38,6 +38,7 @@ namespace SFA.DAS.Activities
 
         [Category(ActivityTypeCategory.AccountAdmin)]
         [Localizer(typeof(AccountNameChangedActivityLocalizer))]
+        [Action("Index", "EmployerTeam")]
         AccountNameChanged = 7,
 
         [Category(ActivityTypeCategory.AccountAdmin)]


### PR DESCRIPTION
This is to fix bug AML-2087, which describes a missing link to the account home page. The account page is the returned by the end point Accounts/xxxx/Teams.