### PR TITLE
AML-2918 Restrict the query to returning at most 4 tube stops

### DIFF
--- a/src/SFA.DAS.Activities.Client.TestHost/CommandLines/QueryCommandLineArgs.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/CommandLines/QueryCommandLineArgs.cs
@@ -2,11 +2,15 @@
 
 namespace SFA.DAS.Activities.Client.TestHost.CommandLines
 {
-    [Verb("query", HelpText=",")]
+    [Verb("query", HelpText= "Executes the GetLatestActivities method on the activities client")]
     public class QueryCommandLineArgs
     {
-        [Option('a', "account", HelpText = "An account to query")]
-        public int AccountId { get; set; }
+        [Option('a', "accounts", HelpText = "Account to query (in print page format, e.g. 1-5,8,11)")]
+        public string AccountIds { get; set; }
+
+
+        [Option('i', "ignoreAccountsNotFound", HelpText = "Do not report acccount ids that do not have any activities", Default = true)]
+        public bool IgnoreNotFound { get; set; }
 
         [Option('t', "type", HelpText = "Type of query to run")]
         public QueryType QueryType { get; set; }

--- a/src/SFA.DAS.Activities.Client.TestHost/Commands/AggregateQueryCommand.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Commands/AggregateQueryCommand.cs
@@ -1,5 +1,8 @@
-﻿using System.Threading;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using PerformanceTester.Types;
 using SFA.DAS.Activities.Client.TestHost.Interfaces;
 
 namespace SFA.DAS.Activities.Client.TestHost.Commands
@@ -8,18 +11,39 @@ namespace SFA.DAS.Activities.Client.TestHost.Commands
     {
         private readonly IActivitiesClient _client;
         private readonly IConfigProvider _configProvider;
+        private readonly IResultSaver _resultSaver;
 
-        public AggregateQueryCommand(IActivitiesClient client, IConfigProvider configProvider)
+        public AggregateQueryCommand(
+            IActivitiesClient client, 
+            IConfigProvider configProvider,
+            IResultSaver resultSaver)
         {
             _client = client;
             _configProvider = configProvider;
+            _resultSaver = resultSaver;
         }
 
-        public Task DoAsync(CancellationToken cancellationToken)
+        public async Task DoAsync(CancellationToken cancellationToken)
         {
             var config = _configProvider.Get<AggregateQueryConfig>();
 
-            return _client.GetLatestActivities(config.AccountId);
+            foreach (var accountId in NumberRange.ToInts(config.AccountIds))
+            {
+                var results = await _client.GetLatestActivities(accountId);
+
+                var tubeStops = results.Aggregates.Count();
+                if (tubeStops == 0 && config.IgnoreNotFound)
+                {
+                    continue;
+                }
+
+                var activitiesCount = results.Aggregates.Sum(a => a.Count);
+
+                Console.WriteLine($"Account id {accountId} found {tubeStops} tube stops covering {activitiesCount} activities");
+
+                await _resultSaver.Save(results);
+
+            }
         }
     }
 }

--- a/src/SFA.DAS.Activities.Client.TestHost/Commands/AggregateQueryConfig.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Commands/AggregateQueryConfig.cs
@@ -2,6 +2,10 @@
 {
     internal class AggregateQueryConfig
     {
-        public long AccountId { get; set; }
+        public string AccountIds { get; set; }
+
+        public string SaveQueryResultsFolder { get; set; }
+
+        public bool IgnoreNotFound { get; set; } = true;
     }
 }

--- a/src/SFA.DAS.Activities.Client.TestHost/Config/ResultFileSaverConfig.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Config/ResultFileSaverConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.Activities.Client.TestHost.Config
+{
+    public class ResultFileSaverConfig
+    {
+        public string FolderName { get; set; }
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/Interfaces/IResultSaver.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Interfaces/IResultSaver.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace SFA.DAS.Activities.Client.TestHost.Interfaces
+{
+    public interface IResultSaver
+    {
+        Task Save<TResult>(TResult results);
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/IoC/CommonRegistry.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/IoC/CommonRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using SFA.DAS.Activities.Client.TestHost.Config;
 using SFA.DAS.Activities.Client.TestHost.Interfaces;
+using SFA.DAS.Activities.Client.TestHost.ResultSavers;
 using StructureMap;
 
 namespace SFA.DAS.Activities.Client.TestHost.IoC
@@ -9,10 +10,11 @@ namespace SFA.DAS.Activities.Client.TestHost.IoC
         public CommonRegistry()
         {
             For<IConfigProvider>().Use<ConfigProvider>().Singleton();
+            For<IResultSaver>().Use<FileResultSaver>();
 
             Scan(scan =>
             {
-                scan.AssembliesFromApplicationBaseDirectory(assembly => assembly.FullName.Contains("PerformanceTester"));
+                scan.AssembliesFromApplicationBaseDirectory(assembly => assembly.FullName.Contains("TestHost"));
                 scan.AddAllTypesOf<ICommand>();
             });
         }

--- a/src/SFA.DAS.Activities.Client.TestHost/Program.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Program.cs
@@ -28,7 +28,8 @@ namespace SFA.DAS.Activities.Client.TestHost
 
         private void RunQuery(QueryCommandLineArgs args)
         {
-            SetConfigOverrides<AggregateQueryConfig>(config => config.AccountId = args.AccountId);
+            SetConfigOverrides<AggregateQueryConfig>(config => config.AccountIds = args.AccountIds);
+            SetConfigOverrides<AggregateQueryConfig>(config => config.IgnoreNotFound = args.IgnoreNotFound);
             RunCommand<AggregateQueryCommand>();
         }
 

--- a/src/SFA.DAS.Activities.Client.TestHost/ResultSavers/FileResultSaver.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/ResultSavers/FileResultSaver.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SFA.DAS.Activities.Client.TestHost.Config;
+using SFA.DAS.Activities.Client.TestHost.Interfaces;
+
+namespace SFA.DAS.Activities.Client.TestHost.ResultSavers
+{
+    public class FileResultSaver : IResultSaver
+    {
+        private readonly IConfigProvider _configProvider;
+
+        public FileResultSaver(IConfigProvider configProvider)
+        {
+            _configProvider = configProvider;
+        }
+
+        public Task Save<TResult>(TResult results)
+        {
+            var config = _configProvider.Get<ResultFileSaverConfig>();
+
+            var fileName = System.IO.Path.Combine(config.FolderName, $"{typeof(TResult).Name}_{DateTime.Now:yyyyMMdd_HHmmss}.json");
+
+            var json = JsonConvert.SerializeObject(results);
+
+            System.IO.File.WriteAllText(fileName, json);
+
+            Console.WriteLine($"Saved output to {fileName}");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.csproj
+++ b/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.csproj
@@ -80,8 +80,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\PerformanceTester.Types\NumberRange.cs">
+      <Link>NumberRange.cs</Link>
+    </Compile>
     <Compile Include="Commands\AggregateQueryCommand.cs" />
     <Compile Include="Commands\AggregateQueryConfig.cs" />
+    <Compile Include="ResultSavers\FileResultSaver.cs" />
+    <Compile Include="Interfaces\IResultSaver.cs" />
+    <Compile Include="Config\ResultFileSaverConfig.cs" />
     <Compile Include="Config\ConfigProvider.cs" />
     <Compile Include="Interfaces\IConfigProvider.cs" />
     <Compile Include="IoC\CommonRegistry.cs" />
@@ -100,7 +106,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
     <None Include="SFA.DAS.Activities.Client.TestHost.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.json
+++ b/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.json
@@ -1,5 +1,9 @@
 ﻿{
   "AggregateQueryConfig": {
 
+  },
+
+  "ResultFileSaverConfig": {
+    "FolderName": "C:\\sfa\\Scripts\\AML-2918"
   }
 }

--- a/src/SFA.DAS.Activities.Client/ActivitiesClient.cs
+++ b/src/SFA.DAS.Activities.Client/ActivitiesClient.cs
@@ -127,7 +127,6 @@ namespace SFA.DAS.Activities.Client
                     .Terms("activitiesByType", t => t
                         .Field(a => a.Type)
                         .Order(new TermsOrder{Key = "maxAt", Order = SortOrder.Descending})
-                        .Size(4)
                         .Aggregations(aggs2 => aggs2
                             .Max("maxAt", m => m
                                 .Field(a => a.At)
@@ -165,6 +164,7 @@ namespace SFA.DAS.Activities.Client
                         };
                     })
                 .OrderByDescending(atod => atod.TopHit.Created)
+                .Take(4)
                 .ToList();
 
             return new AggregatedActivitiesResult


### PR DESCRIPTION
This is a branch off AML-2836 that restricts the number of tube stops to 4. This is off that branch rather than master as the test client host from that branch is needed.
Once this PR is approved it can be merged into the AML-2836 branch which can then be merged into master.