### PR TITLE
AML-2166 Upgrade SFA messaging packages

### DIFF
--- a/src/SFA.DAS.Activities.AcceptanceTests/SFA.DAS.Activities.AcceptanceTests.csproj
+++ b/src/SFA.DAS.Activities.AcceptanceTests/SFA.DAS.Activities.AcceptanceTests.csproj
@@ -109,8 +109,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.Activities.AcceptanceTests/packages.config
@@ -27,7 +27,7 @@
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="SpecFlow" version="2.2.1" targetFramework="net462" />
   <package id="SpecFlow.NUnit" version="2.2.1" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.IntegrationTests/SFA.DAS.Activities.IntegrationTests.csproj
+++ b/src/SFA.DAS.Activities.IntegrationTests/SFA.DAS.Activities.IntegrationTests.csproj
@@ -116,8 +116,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.IntegrationTests/packages.config
+++ b/src/SFA.DAS.Activities.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="5.6.1" targetFramework="net462" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net462" />
+  <package id="Elasticsearch.Net" version="5.6.1" targetFramework="net462" />
   <package id="HtmlTags" version="6.0.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net462" />
@@ -25,8 +25,8 @@
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net462" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net462" />
   <package id="NEST" version="5.6.1" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NLog" version="4.5.0" targetFramework="net462" />
   <package id="NUnit" version="3.9.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net462" />
@@ -35,7 +35,7 @@
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.Jobs/SFA.DAS.Activities.Jobs.csproj
+++ b/src/SFA.DAS.Activities.Jobs/SFA.DAS.Activities.Jobs.csproj
@@ -102,8 +102,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.Jobs/packages.config
+++ b/src/SFA.DAS.Activities.Jobs/packages.config
@@ -20,7 +20,7 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NLog" version="4.5.0" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.MessageHandlers/SFA.DAS.Activities.MessageHandlers.csproj
+++ b/src/SFA.DAS.Activities.MessageHandlers/SFA.DAS.Activities.MessageHandlers.csproj
@@ -125,11 +125,11 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.16\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.105\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.MessageHandlers/packages.config
+++ b/src/SFA.DAS.Activities.MessageHandlers/packages.config
@@ -31,8 +31,8 @@
   <package id="Polly" version="5.7.0" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.1.5" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.UnitTests/SFA.DAS.Activities.UnitTests.csproj
+++ b/src/SFA.DAS.Activities.UnitTests/SFA.DAS.Activities.UnitTests.csproj
@@ -88,11 +88,11 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.16\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.105\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.UnitTests/packages.config
+++ b/src/SFA.DAS.Activities.UnitTests/packages.config
@@ -23,8 +23,8 @@
   <package id="Polly" version="5.7.0" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities/SFA.DAS.Activities.csproj
+++ b/src/SFA.DAS.Activities/SFA.DAS.Activities.csproj
@@ -74,11 +74,11 @@
     <Reference Include="SFA.DAS.Elastic, Version=1.0.0.52762, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Elastic.1.0.0.52762\lib\net45\SFA.DAS.Elastic.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
-    </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.16.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.16\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.6.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StructureMap.4.6.0\lib\net45\StructureMap.dll</HintPath>

--- a/src/SFA.DAS.Activities/packages.config
+++ b/src/SFA.DAS.Activities/packages.config
@@ -16,7 +16,7 @@
   <package id="SFA.DAS.Configuration" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.16" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
The SFA messaging packages have been upgraded to the latest version.

An error was occurring in the previous installed version. The error does not occur in the latest. 

It is not simple to determine what the fixing change was because it the commit that went into the previous version of the nuget is no longer available in VSTS. 