### PR TITLE
AML-1667 Add localiser test

### DIFF
--- a/src/SFA.DAS.Activities.Client.TestHost/CommandLines/LocalizerCommandLineArgs.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/CommandLines/LocalizerCommandLineArgs.cs
@@ -1,0 +1,11 @@
+﻿using CommandLine;
+
+namespace SFA.DAS.Activities.Client.TestHost.CommandLines
+{
+    [Verb("localizer", HelpText= "Executes the localizers against the activities for the specified accounts")]
+    public class LocalizerCommandLineArgs
+    {
+        [Option('a', "accounts", HelpText = "Account to query (in print page format, e.g. 1-5,8,11)")]
+        public string AccountIds { get; set; }
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/Commands/TestLocalizerCommand.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Commands/TestLocalizerCommand.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.Remoting;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceTester.Types;
+using SFA.DAS.Activities.Client.TestHost.Interfaces;
+using SFA.DAS.Activities.Extensions;
+using SFA.DAS.Activities.Localizers;
+
+namespace SFA.DAS.Activities.Client.TestHost.Commands
+{
+    internal class TestLocalizerCommand : ICommand
+    {
+        private readonly IActivitiesClient _client;
+        private readonly IConfigProvider _configProvider;
+        private readonly IResultSaver _resultSaver;
+
+        public TestLocalizerCommand(
+            IActivitiesClient client, 
+            IConfigProvider configProvider,
+            IResultSaver resultSaver)
+        {
+            _client = client;
+            _configProvider = configProvider;
+            _resultSaver = resultSaver;
+        }
+
+        public async Task DoAsync(CancellationToken cancellationToken)
+        {
+            var config = _configProvider.Get<TestLocalizerConfig>();
+
+            foreach (var accountId in NumberRange.ToInts(config.AccountIds))
+            {
+                Console.WriteLine($"Looking for account {accountId}");
+                var results = await _client.GetActivities(new ActivitiesQuery {AccountId = accountId});
+
+                Console.WriteLine($"Account has {results.Total} activities");
+                foreach (var activity in results.Activities)
+                {
+                    Console.Write($"Activity {activity.Id} {activity.Type}");
+                    TryAction(activity, TrySingular, "Singular");
+                    TryAction(activity, TryPlural, "Plural");
+                    Console.WriteLine();
+                }
+            }
+        }
+
+        private void TryAction(Activity activity, Action<IActivityLocalizer, Activity> action, string test)
+        {
+            try
+            {
+                Console.Write($" {test}:");
+                var localizer = activity.Type.GetLocalizer();
+                action(localizer, activity);
+                Console.Write("okay");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed!");
+                Console.WriteLine(e);
+                Console.WriteLine(e.Message);
+            }
+        }
+
+        private void TrySingular(IActivityLocalizer localizer, Activity activity)
+        {
+            var text = localizer.GetSingularText(activity);
+        }
+
+        private void TryPlural(IActivityLocalizer localizer, Activity activity)
+        {
+            var text = localizer.GetPluralText(activity,2);
+        }
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/Commands/TestLocalizerConfig.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Commands/TestLocalizerConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.Activities.Client.TestHost.Commands
+{
+    internal class TestLocalizerConfig
+    {
+        public string AccountIds { get; set; }
+    }
+}

--- a/src/SFA.DAS.Activities.Client.TestHost/Program.cs
+++ b/src/SFA.DAS.Activities.Client.TestHost/Program.cs
@@ -16,10 +16,10 @@ namespace SFA.DAS.Activities.Client.TestHost
 
         private static void Main(string[] args)
         {
-            Parser.Default.ParseArguments<QueryCommandLineArgs>(args)
-                .WithParsed(qcla => new Program().RunQuery(qcla));
+            Parser.Default.ParseArguments<QueryCommandLineArgs, LocalizerCommandLineArgs>(args)
+                .WithParsed<QueryCommandLineArgs>(qcla => new Program().RunQuery(qcla))
+                .WithParsed<LocalizerCommandLineArgs>(localizerArgs => new Program().TestLocalizers(localizerArgs));
         }
-
 
         public Program()
         {
@@ -31,6 +31,12 @@ namespace SFA.DAS.Activities.Client.TestHost
             SetConfigOverrides<AggregateQueryConfig>(config => config.AccountIds = args.AccountIds);
             SetConfigOverrides<AggregateQueryConfig>(config => config.IgnoreNotFound = args.IgnoreNotFound);
             RunCommand<AggregateQueryCommand>();
+        }
+
+        private void TestLocalizers(LocalizerCommandLineArgs args)
+        {
+            SetConfigOverrides<TestLocalizerConfig>(config => config.AccountIds = args.AccountIds);
+            RunCommand<TestLocalizerCommand>();
         }
 
         private void RunCommand<TCommand>() where TCommand : ICommand

--- a/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.csproj
+++ b/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.csproj
@@ -83,7 +83,10 @@
     <Compile Include="..\PerformanceTester.Types\NumberRange.cs">
       <Link>NumberRange.cs</Link>
     </Compile>
+    <Compile Include="CommandLines\LocalizerCommandLineArgs.cs" />
+    <Compile Include="Commands\TestLocalizerCommand.cs" />
     <Compile Include="Commands\AggregateQueryCommand.cs" />
+    <Compile Include="Commands\TestLocalizerConfig.cs" />
     <Compile Include="Commands\AggregateQueryConfig.cs" />
     <Compile Include="ResultSavers\FileResultSaver.cs" />
     <Compile Include="Interfaces\IResultSaver.cs" />
@@ -103,6 +106,10 @@
     <ProjectReference Include="..\SFA.DAS.Activities.Client\SFA.DAS.Activities.Client.csproj">
       <Project>{45344a34-429e-441c-a69c-8d7539353c51}</Project>
       <Name>SFA.DAS.Activities.Client</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SFA.DAS.Activities\SFA.DAS.Activities.csproj">
+      <Project>{744fdb51-c5ff-4b5b-a380-9cde153277cf}</Project>
+      <Name>SFA.DAS.Activities</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.json
+++ b/src/SFA.DAS.Activities.Client.TestHost/SFA.DAS.Activities.Client.TestHost.json
@@ -5,5 +5,9 @@
 
   "ResultFileSaverConfig": {
     "FolderName": "C:\\sfa\\Scripts\\AML-2918"
-  }
+  },
+
+  "TestLocalizerConfig": {
+
+  } 
 }


### PR DESCRIPTION
Add a command to the client tester to allow the localisers to be tested against a specific account. If one of the localisers fail because of the missing data then the activities page would fail completely. This has now changed so that the localizer data issues will now result in a generic message. This new command will run all the localizers against specified accounts and output any data problems.