### PR TITLE
Update message handlers to use the new MessageProcessor2 class

### DIFF
--- a/src/SFA.DAS.Activities.AcceptanceTests/SFA.DAS.Activities.AcceptanceTests.csproj
+++ b/src/SFA.DAS.Activities.AcceptanceTests/SFA.DAS.Activities.AcceptanceTests.csproj
@@ -109,8 +109,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.Activities.AcceptanceTests/packages.config
@@ -27,7 +27,7 @@
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="SpecFlow" version="2.2.1" targetFramework="net462" />
   <package id="SpecFlow.NUnit" version="2.2.1" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.IntegrationTests/SFA.DAS.Activities.IntegrationTests.csproj
+++ b/src/SFA.DAS.Activities.IntegrationTests/SFA.DAS.Activities.IntegrationTests.csproj
@@ -116,8 +116,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.IntegrationTests/packages.config
+++ b/src/SFA.DAS.Activities.IntegrationTests/packages.config
@@ -35,7 +35,7 @@
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.Jobs/SFA.DAS.Activities.Jobs.csproj
+++ b/src/SFA.DAS.Activities.Jobs/SFA.DAS.Activities.Jobs.csproj
@@ -102,8 +102,8 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.Jobs/packages.config
+++ b/src/SFA.DAS.Activities.Jobs/packages.config
@@ -20,7 +20,7 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NLog" version="4.5.0" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.MessageHandlers/ActivitiesWorkerRegistry.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/ActivitiesWorkerRegistry.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.Activities.MessageHandlers
             Scan(s =>
             {
                 s.AssemblyContainingType<ActivitiesWorkerRegistry>();
-                s.AddAllTypesOf<IMessageProcessor>();
+                s.AddAllTypesOf<IMessageProcessor2>();
             });
         }
     }

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AccountCreatedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AccountCreatedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_AccountCreatedMessageProcessor")]
-    public class AccountCreatedMessageProcessor : MessageProcessor<AccountCreatedMessage>
+    public class AccountCreatedMessageProcessor : MessageProcessor2<AccountCreatedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AccountNameChangedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AccountNameChangedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_AccountNameChangedMessageProcessor")]
-    public class AccountNameChangedMessageProcessor : MessageProcessor<AccountNameChangedMessage>
+    public class AccountNameChangedMessageProcessor : MessageProcessor2<AccountNameChangedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AgreementSignedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/AgreementSignedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_AgreementSignedMessageProcessor")]
-    public class AgreementSignedMessageProcessor : MessageProcessor<AgreementSignedMessage>
+    public class AgreementSignedMessageProcessor : MessageProcessor2<AgreementSignedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/LegalEntityAddedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/LegalEntityAddedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_LegalEntityAddedMessageProcessor")]
-    public class LegalEntityAddedMessageProcessor : MessageProcessor<LegalEntityAddedMessage>
+    public class LegalEntityAddedMessageProcessor : MessageProcessor2<LegalEntityAddedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/LegalEntityRemovedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/LegalEntityRemovedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_LegalEntityRemovedMessageProcessor")]
-    public class LegalEntityRemovedMessageProcessor : MessageProcessor<LegalEntityRemovedMessage>
+    public class LegalEntityRemovedMessageProcessor : MessageProcessor2<LegalEntityRemovedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PayeSchemeAddedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PayeSchemeAddedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_PayeSchemeAddedMessageProcessor")]
-    public class PayeSchemeAddedMessageProcessor : MessageProcessor<PayeSchemeAddedMessage>
+    public class PayeSchemeAddedMessageProcessor : MessageProcessor2<PayeSchemeAddedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PayeSchemeRemovedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PayeSchemeRemovedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_PayeSchemeDeletedMessageProcessor")]
-    public class PayeSchemeRemovedMessageProcessor : MessageProcessor<PayeSchemeDeletedMessage>
+    public class PayeSchemeRemovedMessageProcessor : MessageProcessor2<PayeSchemeDeletedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PaymentCreatedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/PaymentCreatedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_PaymentCreatedMessageProcessor")]
-    public class PaymentCreatedMessageProcessor : MessageProcessor<PaymentCreatedMessage>
+    public class PaymentCreatedMessageProcessor : MessageProcessor2<PaymentCreatedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/UserInvitedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/UserInvitedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_UserInvitedMessageProcessor")]
-    public class UserInvitedMessageProcessor : MessageProcessor<UserInvitedMessage>
+    public class UserInvitedMessageProcessor : MessageProcessor2<UserInvitedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/UserJoinedMessageProcessor.cs
+++ b/src/SFA.DAS.Activities.MessageHandlers/MessageProcessors/UserJoinedMessageProcessor.cs
@@ -8,7 +8,7 @@ using SFA.DAS.NLog.Logger;
 namespace SFA.DAS.Activities.MessageHandlers.MessageProcessors
 {
     [TopicSubscription("Activity_UserJoinedMessageProcessor")]
-    public class UserJoinedMessageProcessor : MessageProcessor<UserJoinedMessage>
+    public class UserJoinedMessageProcessor : MessageProcessor2<UserJoinedMessage>
     {
         private readonly IActivitySaver _activitySaver;
 

--- a/src/SFA.DAS.Activities.MessageHandlers/SFA.DAS.Activities.MessageHandlers.csproj
+++ b/src/SFA.DAS.Activities.MessageHandlers/SFA.DAS.Activities.MessageHandlers.csproj
@@ -125,11 +125,11 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.105\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.120\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.MessageHandlers/packages.config
+++ b/src/SFA.DAS.Activities.MessageHandlers/packages.config
@@ -31,8 +31,8 @@
   <package id="Polly" version="5.7.0" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.1.5" targetFramework="net462" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net462" />

--- a/src/SFA.DAS.Activities.UnitTests/MessageProcessorTest.cs
+++ b/src/SFA.DAS.Activities.UnitTests/MessageProcessorTest.cs
@@ -11,7 +11,7 @@ using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.Activities.UnitTests
 {
-    public abstract class MessageProcessorTest<TMessageProcessor> where TMessageProcessor : IMessageProcessor
+    public abstract class MessageProcessorTest<TMessageProcessor> where TMessageProcessor : IMessageProcessor2
     {
         protected FromMessage<TMessage> From<TMessage>(TMessage from) where TMessage : class, new()
         {
@@ -58,7 +58,7 @@ namespace SFA.DAS.Activities.UnitTests
                 return this;
             }
 
-            public void Verify(Func<MessageProcessorTestFixtures<TMessage>, IMessageProcessor> createProcessor)
+            public void Verify(Func<MessageProcessorTestFixtures<TMessage>, IMessageProcessor2> createProcessor)
             {
                 var cancellationTokenSource = new CancellationTokenSource();
                 var mappedActivity = new Activity();
@@ -78,7 +78,7 @@ namespace SFA.DAS.Activities.UnitTests
                     typeof(TMessage).CustomAttributes.SingleOrDefault(a =>
                         a.AttributeType == typeof(MessageGroupAttribute));
 
-                messageProcessor.RunAsync(cancellationTokenSource).Wait();
+                messageProcessor.RunAsync(cancellationTokenSource.Token).Wait();
 
                 Assert.That(topicSubscriptionAttribute, Is.Not.Null);
                 Assert.That(messageGroupAttribute, Is.Not.Null);

--- a/src/SFA.DAS.Activities.UnitTests/SFA.DAS.Activities.UnitTests.csproj
+++ b/src/SFA.DAS.Activities.UnitTests/SFA.DAS.Activities.UnitTests.csproj
@@ -88,11 +88,11 @@
     <Reference Include="SFA.DAS.EmployerAccounts.Events, Version=1.2.0.62826, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerAccounts.Events.1.2.0.62826\lib\net45\SFA.DAS.EmployerAccounts.Events.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.105\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging.AzureServiceBus, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.AzureServiceBus.3.1.120\lib\net45\SFA.DAS.Messaging.AzureServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities.UnitTests/packages.config
+++ b/src/SFA.DAS.Activities.UnitTests/packages.config
@@ -23,8 +23,8 @@
   <package id="Polly" version="5.7.0" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
   <package id="SFA.DAS.EmployerAccounts.Events" version="1.2.0.62826" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging.AzureServiceBus" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Activities/SFA.DAS.Activities.csproj
+++ b/src/SFA.DAS.Activities/SFA.DAS.Activities.csproj
@@ -74,8 +74,8 @@
     <Reference Include="SFA.DAS.Elastic, Version=1.0.0.52762, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Elastic.1.0.0.52762\lib\net45\SFA.DAS.Elastic.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Messaging, Version=3.1.105.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Messaging.3.1.105\lib\net45\SFA.DAS.Messaging.dll</HintPath>
+    <Reference Include="SFA.DAS.Messaging, Version=3.1.120.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Messaging.3.1.120\lib\net45\SFA.DAS.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.1.5\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>

--- a/src/SFA.DAS.Activities/packages.config
+++ b/src/SFA.DAS.Activities/packages.config
@@ -16,7 +16,7 @@
   <package id="SFA.DAS.Configuration" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Elastic" version="1.0.0.52762" targetFramework="net462" />
-  <package id="SFA.DAS.Messaging" version="3.1.105" targetFramework="net462" />
+  <package id="SFA.DAS.Messaging" version="3.1.120" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.1.5" targetFramework="net462" />
   <package id="StructureMap" version="4.6.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />


### PR DESCRIPTION
Previously the message handlers would all be cancelled if _any_ message handler encountered a problem. This no longer happens. 
If an exception occurs in a message processor then that message processor will be terminated. This is probably desirable since transient problems interacting with ServiceBus are already handled using Poly. 
